### PR TITLE
Add Option to Exclude Squared Preview Sizes

### DIFF
--- a/lib/src/main/java/com/ragnarok/rxcamera/RxCameraInternal.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/RxCameraInternal.java
@@ -135,9 +135,16 @@ public class RxCameraInternal implements SurfaceCallback.SurfaceListener, Camera
         // set preview size;
         if (cameraConfig.preferPreviewSize != null) {
             try {
-                Camera.Size previewSize = CameraUtil.findClosetPreviewSize(camera, cameraConfig.preferPreviewSize);
-                parameters.setPreviewSize(previewSize.width, previewSize.height);
-                finalPreviewSize = new Point(previewSize.width, previewSize.height);
+                //check wether squared preview is accepted or not.
+                if(cameraConfig.acceptSquarePreview) {
+                    Camera.Size previewSize = CameraUtil.findClosestPreviewSize(camera, cameraConfig.preferPreviewSize);
+                    parameters.setPreviewSize(previewSize.width, previewSize.height);
+                    finalPreviewSize = new Point(previewSize.width, previewSize.height);
+                } else {
+                    Camera.Size previewSize = CameraUtil.findClosestNonSquarePreviewSize(camera, cameraConfig.preferPreviewSize);
+                    parameters.setPreviewSize(previewSize.width, previewSize.height);
+                    finalPreviewSize = new Point(previewSize.width, previewSize.height);
+                }
             } catch (Exception e) {
                 openCameraFailedReason = OpenCameraFailedReason.SET_PREVIEW_SIZE_FAILED;
                 openCameraFailedCause = e;

--- a/lib/src/main/java/com/ragnarok/rxcamera/config/CameraUtil.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/config/CameraUtil.java
@@ -137,7 +137,7 @@ public class CameraUtil {
         return result;
     }
 
-    public static Camera.Size findClosetPreviewSize(Camera camera, Point preferSize) {
+    public static Camera.Size findClosestPreviewSize(Camera camera, Point preferSize) {
         int preferX = preferSize.x;
         int preferY = preferSize.y;
         Camera.Parameters parameters = camera.getParameters();
@@ -154,6 +154,31 @@ public class CameraUtil {
             if (diff < minDiff) {
                 minDiff = diff;
                 index = i;
+            }
+        }
+
+        Camera.Size size = allSupportSizes.get(index);
+        return size;
+    }
+
+    public static Camera.Size findClosestNonSquarePreviewSize(Camera camera, Point preferSize) {
+        int preferX = preferSize.x;
+        int preferY = preferSize.y;
+        Camera.Parameters parameters = camera.getParameters();
+        List<Camera.Size> allSupportSizes = parameters.getSupportedPreviewSizes();
+        Log.d(TAG, "all support preview size: " + dumpPreviewSizeList(allSupportSizes));
+        int minDiff = Integer.MAX_VALUE;
+        int index = 0;
+        for (int i = 0; i < allSupportSizes.size(); i++) {
+            Camera.Size size = allSupportSizes.get(i);
+            int x = size.width;
+            int y = size.height;
+            if (x != y) {
+                int diff = Math.abs(x - preferX) + Math.abs(y - preferY);
+                if (diff < minDiff) {
+                    minDiff = diff;
+                    index = i;
+                }
             }
         }
 

--- a/lib/src/main/java/com/ragnarok/rxcamera/config/RxCameraConfig.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/config/RxCameraConfig.java
@@ -16,6 +16,8 @@ public class RxCameraConfig {
 
     public Point preferPreviewSize = null;
 
+    public boolean acceptSquarePreview = true;
+
     public int minPreferPreviewFrameRate = -1;
 
     public int maxPreferPreviewFrameRate = -1;
@@ -44,6 +46,7 @@ public class RxCameraConfig {
         result.append(String.format("previewBufferSize: %d, ", previewBufferSize));
         result.append(String.format("isHandleSurfaceEvent: %b, ", isHandleSurfaceEvent));
         result.append(String.format("cameraOrien: %d, ", cameraOrien));
+        result.append(String.format("acceptSquarePreview: %s", acceptSquarePreview));
         return result.toString();
     }
 }

--- a/lib/src/main/java/com/ragnarok/rxcamera/config/RxCameraConfigChooser.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/config/RxCameraConfigChooser.java
@@ -32,11 +32,12 @@ public class RxCameraConfigChooser {
         return this;
     }
 
-    public RxCameraConfigChooser setPreferPreviewSize(Point size) {
+    public RxCameraConfigChooser setPreferPreviewSize(Point size, boolean acceptSquarePreview) {
         if (size == null) {
             return this;
         }
         configResult.preferPreviewSize = size;
+        configResult.acceptSquarePreview = acceptSquarePreview;
         return this;
     }
 


### PR DESCRIPTION
I think this is necessary because some people may want to see a Full-Screen preview at the Maximum Preview Size but some devices (like the Galaxy S4) have the maximum preview size square (1340x1340) and that preview is absolutely stretched!
