### PR TITLE
Config supports disabling shutter sound. Also fix crash when setDisplayOrientation is not used in config.

### DIFF
--- a/lib/src/main/java/com/ragnarok/rxcamera/RxCameraInternal.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/RxCameraInternal.java
@@ -194,7 +194,7 @@ public class RxCameraInternal implements SurfaceCallback.SurfaceListener, Camera
         // set display orientation
         int displayOrientation = cameraConfig.displayOrientation;
         if (displayOrientation == -1) {
-            displayOrientation = CameraUtil.getPortraitCamearaDisplayOrientation(context, cameraConfig.currentCameraId, cameraConfig.isFaceCamera);
+            displayOrientation = CameraUtil.getPortraitCameraDisplayOrientation(context, cameraConfig.currentCameraId, cameraConfig.isFaceCamera);
         }
         try {
             camera.setDisplayOrientation(displayOrientation);

--- a/lib/src/main/java/com/ragnarok/rxcamera/RxCameraInternal.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/RxCameraInternal.java
@@ -3,8 +3,8 @@ package com.ragnarok.rxcamera;
 import android.content.Context;
 import android.graphics.ImageFormat;
 import android.graphics.Point;
-import android.graphics.SurfaceTexture;
 import android.hardware.Camera;
+import android.os.Build;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -178,6 +178,14 @@ public class RxCameraInternal implements SurfaceCallback.SurfaceListener, Camera
                 openCameraFailedReason = OpenCameraFailedReason.SET_AUTO_FOCUS_FAILED;
                 openCameraFailedCause = e;
                 return false;
+            }
+        }
+
+        // set enableShutterSound (only supported for API 17 and newer)
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1
+                && cameraConfig.muteShutterSound) {
+            if (CameraUtil.canDisableShutter(cameraConfig.currentCameraId)) {
+                camera.enableShutterSound(false);
             }
         }
 

--- a/lib/src/main/java/com/ragnarok/rxcamera/config/CameraUtil.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/config/CameraUtil.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.hardware.Camera;
+import android.os.Build;
 import android.util.Log;
-import android.util.Size;
 import android.view.Surface;
 import android.view.WindowManager;
 
@@ -213,5 +213,16 @@ public class CameraUtil {
             result = center - focusAreaSize / 2;
         }
         return result;
+    }
+
+    public static boolean canDisableShutter(int id) {
+        // cameraInfo.canDisableShutterSound is only available for API 17 and newer
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            Camera.CameraInfo cameraInfo = getCameraInfo(id);
+            return cameraInfo != null && cameraInfo.canDisableShutterSound;
+        } else {
+            Log.d(TAG, "SDK does not support disabling shutter sound");
+            return false;
+        }
     }
 }

--- a/lib/src/main/java/com/ragnarok/rxcamera/config/CameraUtil.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/config/CameraUtil.java
@@ -75,7 +75,7 @@ public class CameraUtil {
         return backCameraId;
     }
 
-    public static int getPortraitCamearaDisplayOrientation(Context context, int cameraId, boolean isFrontCamera) {
+    public static int getPortraitCameraDisplayOrientation(Context context, int cameraId, boolean isFrontCamera) {
         if (cameraId < 0 || cameraId > getCameraNumber()) {
             return -1;
         }

--- a/lib/src/main/java/com/ragnarok/rxcamera/config/RxCameraConfig.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/config/RxCameraConfig.java
@@ -35,6 +35,8 @@ public class RxCameraConfig {
 
     public final int cameraOrientation;
 
+    public final boolean muteShutterSound;
+
     public RxCameraConfig(Builder builder) {
         isFaceCamera = builder.isFaceCamera;
         currentCameraId = builder.currentCameraId;
@@ -48,6 +50,7 @@ public class RxCameraConfig {
         previewBufferSize = builder.previewBufferSize;
         isHandleSurfaceEvent = builder.isHandleSurfaceEvent;
         cameraOrientation = builder.cameraOrientation;
+        muteShutterSound = builder.muteShutterSound;
     }
 
     @Override
@@ -62,7 +65,8 @@ public class RxCameraConfig {
         result.append(String.format("previewBufferSize: %d, ", previewBufferSize));
         result.append(String.format("isHandleSurfaceEvent: %b, ", isHandleSurfaceEvent));
         result.append(String.format("cameraOrientation: %d, ", cameraOrientation));
-        result.append(String.format("acceptSquarePreview: %s", acceptSquarePreview));
+        result.append(String.format("acceptSquarePreview: %s, ", acceptSquarePreview));
+        result.append(String.format("muteShutterSound: %s", muteShutterSound));
         return result.toString();
     }
 
@@ -79,6 +83,7 @@ public class RxCameraConfig {
         private int previewBufferSize = -1;
         private boolean isHandleSurfaceEvent = false;
         private int cameraOrientation = -1;
+        private boolean muteShutterSound = false;
 
         public Builder useFrontCamera() {
             isFaceCamera = true;
@@ -138,6 +143,11 @@ public class RxCameraConfig {
 
         public Builder setPreviewBufferSize(int size) {
             previewBufferSize = size;
+            return this;
+        }
+
+        public Builder setMuteShutterSound(boolean mute){
+            muteShutterSound = mute;
             return this;
         }
 

--- a/lib/src/main/java/com/ragnarok/rxcamera/config/RxCameraConfig.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/config/RxCameraConfig.java
@@ -116,6 +116,12 @@ public class RxCameraConfig {
         }
 
         public Builder setDisplayOrientation(int displayOrientation) {
+            if (displayOrientation != 0 &&
+                    displayOrientation != 90 &&
+                    displayOrientation != 180 &&
+                    displayOrientation != 270)
+                throw new IllegalArgumentException("display orientation: " +displayOrientation + ". (must be 0, 90, 180, or 270)");
+
             this.displayOrientation = displayOrientation;
             return this;
         }
@@ -156,11 +162,6 @@ public class RxCameraConfig {
 
         public RxCameraConfig build() {
             setProperConfigVal();
-            if (displayOrientation != 0 &&
-                    displayOrientation != 90 &&
-                    displayOrientation != 180 &&
-                    displayOrientation != 270)
-                throw new IllegalArgumentException("display orientation: " +displayOrientation + ". (must be 0, 90, 180, or 270)");
             return new RxCameraConfig(this);
         }
     }


### PR DESCRIPTION
This pull request allows you to set RxCameraConfig.Builder().setMuteShutterSound(true) in order to mute the shutter sound when taking a picture. The implementation checks the SDK level because it uses CameraInfo.canDisableShutterSound, which was added in API 17.

While doing this I realised that the example app was crashing, so I also fixed that. When building RxCameraConfig, there was a check for displayOrientation to be a valid value. The problem was that the default value for displayOrientation is -1, which does not pass the check. I moved the check inside the method setDisplayOrientation(int displayOrientation).

I also fixed a typo ;-)
