### PR TITLE
Removed Thread.sleep from TakePictureRequest

### DIFF
--- a/lib/src/main/java/com/ragnarok/rxcamera/request/TakePictureRequest.java
+++ b/lib/src/main/java/com/ragnarok/rxcamera/request/TakePictureRequest.java
@@ -82,12 +82,6 @@ public class TakePictureRequest extends BaseRxCameraRequest {
                     e.printStackTrace();
                 }
 
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-
                 rxCamera.getNativeCamera().takePicture(new Camera.ShutterCallback() {
                     @Override
                     public void onShutter() {


### PR DESCRIPTION
This looks like some left over debugging code, `camera.request().takePictureRequest` performs a lot quicker without this. If I've misunderstood its purpose and it's not ok to remove it please let me know 👍 . 
